### PR TITLE
pom updated for ec2 since shade plugin doesn't add the mail class  an…

### DIFF
--- a/ticket-booking-lambda/pom.xml
+++ b/ticket-booking-lambda/pom.xml
@@ -66,7 +66,7 @@
             </executions>
         </plugin>
 
-        <!-- Shade plugin (ONLY for Lambda) -->
+        <!-- Shade plugin (ONLY for Lambda) 
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
@@ -82,7 +82,7 @@
                     </configuration>
                 </execution>
             </executions>
-        </plugin>
+        </plugin>-->
 
     </plugins>
 </build>


### PR DESCRIPTION
…d lamda doen't required the mail class handler workes in lamda and main required to ec2 so that it include the tomcate