### PR TITLE
pom updated for ec2 since shade plugin doesn't add the mail class  an…

### DIFF
--- a/ticket-booking-lambda/pom.xml
+++ b/ticket-booking-lambda/pom.xml
@@ -57,16 +57,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
             <version>3.2.5</version>
-           <!-- <executions>
+            <executions>
                 <execution>
                     <goals>
                         <goal>repackage</goal>
                     </goals>
                 </execution>
             </executions>
-        </plugin>-->
+        </plugin>
 
-        <!-- Shade plugin (ONLY for Lambda) 
+        <!-- Shade plugin (ONLY for Lambda) -->
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
@@ -81,7 +81,7 @@
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                     </configuration>
                 </execution>
-            </executions>-->
+            </executions>
         </plugin>
 
     </plugins>


### PR DESCRIPTION
…d lamda doen't required the mail class handler workes in lamda and main required to ec2 so that it include the tomcate